### PR TITLE
[#9] #3, #4 기능에 대한 test case 작성

### DIFF
--- a/console-service/src/test/java/com/lima/consoleservice/domain/user/service/UserServiceTest.java
+++ b/console-service/src/test/java/com/lima/consoleservice/domain/user/service/UserServiceTest.java
@@ -1,0 +1,188 @@
+package com.lima.consoleservice.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lima.consoleservice.common.exception.ErrorCode;
+import com.lima.consoleservice.config.Hasher;
+import com.lima.consoleservice.config.security.JwtTokenProvider;
+import com.lima.consoleservice.domain.repository.UserRepository;
+import com.lima.consoleservice.domain.repository.entity.User;
+import com.lima.consoleservice.domain.repository.entity.UserCredentials;
+import com.lima.consoleservice.domain.user.model.request.CreateUserRequest;
+import com.lima.consoleservice.domain.user.model.request.LoginUserRequest;
+import com.lima.consoleservice.domain.user.model.request.UpdateUserRequest;
+import com.lima.consoleservice.domain.user.model.response.AuthResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+/*
+  @Mock
+  목적: 특정 클래스의 Mock 객체(가짜 객체)를 생성한다.
+  테스트 환경에서 테스트 대상 객체의 의존성을 대체하는 데 사용 된다.
+  @Mock은 의존성 주입과 무관하며, 단순히 Mock 객체를 생성하기만 한다.
+
+  @InjectMocks
+  목적: 테스트 대상 객체를 생성하고, @Mock으로 생성된 Mock 객체들을 자동으로 주입한다.
+  Mock 객체와 테스트 대상 객체를 연결해주는 역할을 한다.
+  의존성 주입 방식은 생성자, 필드, 세터를 통해 이루어질 수 있다.
+
+  @Spy
+  실제 객체를 감싸고, 기본적으로 실제 객체의 동작을 사용하지만, 특정 메서드에 대해서만 stub(대체)할 수 있다.
+  when(userService.getCurrentUserEmail()).thenReturn(email); 때문에 추가 하였다.
+ */
+
+@SpringBootTest
+class UserServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Spy
+  @InjectMocks
+  private UserService userService;
+
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private RedisTemplate<String, String> redisTemplate;
+
+  // Spring Data Redis 에서 제공하는 인터페이스 이고, Redis 의 String 타입 값에 대해 조작할 수 있는 기능을 제공한다.
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
+  @BeforeEach
+  void setUp() {
+    // RedisTemplate의 opsForValue() 설정
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+  }
+
+  @Test
+  void createUser() {
+    // Given
+    String email = "lima@gmail.com";
+    String name = "HelloTest";
+    String password = "1016";
+
+    CreateUserRequest request = new CreateUserRequest(email, name, password);
+
+    // UserRepository에서 이메일이 존재하지 않는다고 가정.
+    when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+    // UserRepository의 save 메서드가 호출될 때 가짜로 저장된 User 객체를 반환하도록 설정하자.
+    when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+    // When
+    AuthResponse response = userService.createUser(request);
+
+    // Then
+    assertEquals(ErrorCode.SUCCESS.getMessage(), response.code());
+    assertEquals(email, response.result());
+
+    // Verify: userRepository.findByEmail과 save 메서드가 호출되었는지 확인
+    verify(userRepository).findByEmail(email);
+    verify(userRepository).save(any(User.class));
+  }
+
+  @Test
+  void login() {
+    // Given
+    String email = "lima@gmail.com";
+    String password = "1016";
+    Hasher hasher = new Hasher("SHA-256");
+    LoginUserRequest request = new LoginUserRequest(email, password);
+
+    // UserRepository에서 이메일이 존재 한다고 가정.
+    when(userRepository.findByEmail(email))
+        .thenReturn(
+            Optional.of(User.builder()
+                .email(email)
+                .userCredentials(
+                    UserCredentials.builder().hashedPassword(hasher.getHashingValue(password))
+                        .build())
+                .build())
+        ).thenAnswer(i -> i.getArguments()[0]);
+
+    // Mock JwtTokenProvider
+    when(jwtTokenProvider.createToken(email)).thenReturn("mock-token");
+
+    // When
+    AuthResponse response = userService.login(request);
+
+    // Then
+    assertEquals(ErrorCode.SUCCESS.getMessage(), response.code());
+    assertEquals("mock-token", response.result());
+  }
+
+  @Test
+  void logout() {
+    // Given
+    String name = "HelloTest";
+    String email = "lima@gmail.com";
+    long userId = 1L;
+
+    // 찾는 유저가 있다고 가정
+    when(userRepository.findById(userId))
+        .thenReturn(Optional.of(User.builder().name(name).email(email).build()));
+    when(userService.getCurrentUserEmail()).thenReturn(email);
+
+    // When
+    AuthResponse logout = userService.logout(userId);
+
+    // Then
+    assertEquals(ErrorCode.SUCCESS.getMessage(), logout.code());
+  }
+
+  @Test
+  void updateUser() {
+    // Given
+    String name = "HelloTest";
+    String email = "lima@gmail.com";
+    long userId = 1L;
+
+    UpdateUserRequest request = new UpdateUserRequest(name);
+
+    // 찾는 유저가 있다고 가정
+    when(userRepository.findById(userId))
+        .thenReturn(Optional.of(User.builder().name(name).email(email).build()));
+    when(userService.getCurrentUserEmail()).thenReturn(email);
+
+    // When
+    AuthResponse response = userService.updateUser(userId, request);
+
+    // Then
+    assertEquals(ErrorCode.SUCCESS.getMessage(), response.code());
+    assertEquals(name, response.result());
+  }
+
+  @Test
+  void deleteUser() {
+    // Given
+    String name = "HelloTest";
+    String email = "lima@gmail.com";
+    long userId = 1L;
+
+    // LIMA: 해당 부분이 중복되는 경우가 많은데 Given 부터 중복되는 부분을 @BeforeEach에 몰아서 써도 될까?
+    // 찾는 유저가 있다고 가정
+    when(userRepository.findById(userId))
+        .thenReturn(Optional.of(User.builder().name(name).email(email).build()));
+    when(userService.getCurrentUserEmail()).thenReturn(email);
+
+    // When
+    AuthResponse response = userService.deleteUser(userId);
+
+    // Then
+    assertEquals(ErrorCode.SUCCESS.getMessage(), response.code());
+  }
+}


### PR DESCRIPTION
### 관련 이슈: #9 

### 내용: 
유저 생성, 로그인, 로그아웃에, 유저 정보 업데이트, 유저 삭제 대한 test case 작성
관련 클래스: /test/java/com/lima/consoleservice/domain/user/service/UserServiceTest.java

#### 유저 생성(createUserSuccess(), createUserAlreadyExists())
- 유저 생성시 해당 유저가 없다는 가정하에 생성 -> 생성 성공
- 유저 생성시 해당 유저가 있다고 가정하에 테스트 -> USER_ALREADY_EXISTS 발생 확인
- 유저 생성시 save 후 가짜 User에 대한 정보 반환
- 유저 생성 후 생성시 적은 email과 생성된 email이 같은지 비교

#### 로그인(loginSuccess(), loginNotExistUser())
- User가 이미 존재한다고 가정 -> 로그인 성공
- User가 존재 하지 않는다고 가정 -> NOT_EXIST_USER 발생 확인
- 로그인 시도시 mock로 jwt 토큰 비교

#### 로그아웃(logoutSuccess(), logoutNotExistUser())
- 로그아웃을 시도하는 유저가 있다고 가정 -> 로그아웃 성공
- 로그아웃을 시도하는 유저가 없다고 가정 -> NOT_EXIST_USER 발생 확인

#### 유저 정보 업데이트(updateUserSuccess(), updateUserNotExistUser())
- 유저 업데이트시 찾는 유저가 있다고 가정 -> 유저 정보 업데이트 성공
- 유저 업데이트시 찾는 유저가 없다고 가정 -> NOT_EXIST_USER 발생 확인
- 유저 업데이트후 업데이트하려고하는 name과 반환된 name이 같은지 비교
##### 트러블슈팅
- 문제: when() 구문에서 userService.getCurrentUserEmail()  호출시 mock 에러 확인 
- 원인: UserService는 주입받는 클래스라 @Mock 어노테이션이 아닌 @InjectMocks 를 사용하였기 때문에 나온 에러
- 해결: @Spy 어노테이션을 추가해줌으로 해당 문제를 해결 하였음.
- 정리글: https://lima1016.tistory.com/199 

#### 유저 정보 삭제(deleteUserSuccess(), )
- 유저 삭제시 찾는 유저가 있다고 가정 -> 유저 정보 삭제 성공
- 유저 삭제시 찾는 유저가 없다고 가정 -> NOT_EXIST_USER 발생 확인
- 유저 삭제후 성공 코드 비교

